### PR TITLE
feature: hoist static virtual dom nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lerna/legacy-package-management": "^8.2.4",
-        "@lvce-editor/eslint-config": "^16.4.0",
+        "@lvce-editor/eslint-config": "^17.0.3",
         "eslint": "^10.7.0",
         "lerna": "^8.2.4",
         "prettier": "^3.8.4",
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.4.0.tgz",
-      "integrity": "sha512-vc382ImEo+upv9LR+kr0vSpfyV8BBxKb+m2nCBVXjGm7eu5Cw9zTPv9X+mxOjWiNkUyWfuwY+NgbgsSC4Scu8g==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
+      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1713,14 +1713,14 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.4.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.4.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.4.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.4.0",
-        "@lvce-editor/eslint-plugin-regex": "16.4.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.4.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.4.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.4.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
+        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
+        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
+        "@lvce-editor/eslint-plugin-regex": "17.0.3",
+        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -1735,9 +1735,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.4.0.tgz",
-      "integrity": "sha512-KWAhBTB5GZrgFoL16rYvY6QI+MHUd5kQ++uFWpV8WE2/pF4RI2xiOTft7lfWUD+EARG9ygyRFbgtVO0RFlFOQw==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
+      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1745,16 +1745,16 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.4.0.tgz",
-      "integrity": "sha512-kS1IGkvUeOZeVUGs+fxSOzGqqXRwWL1dZq1Kq0KHo24gNZ/WqKi2cLVWpAAyQZA+P0dp82SG7WwZ+NZHhPYoSA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
+      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-16.4.0.tgz",
-      "integrity": "sha512-T66LFDS0nX3/H5nxFiNIkUMEou55FlOxLgOfkbCivZdQQ+fTZnNYb1zOdkxk9hKzQC6RaO4Oj0soilT02TDOQQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
+      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1763,9 +1763,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.4.0.tgz",
-      "integrity": "sha512-/vx42EiKdt8E7oJ+pbTTKC+V9tgO7yiLKnHlXi664A/s4rEQOfJbB9wq4HYY2hmsDymGokKcNCJNOrdE8GwszA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
+      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1786,23 +1786,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.4.0.tgz",
-      "integrity": "sha512-XOVlNT6inumz2GLe70A5yuqRvEhGtXe2aCwtCuAnbkD5d1HH5G5NwSA374sF6Z+Kiy02s23eVfxOk+0oh2yQ6g==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
+      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.4.0.tgz",
-      "integrity": "sha512-ghI9uGpUyxPnJnVgKojf0RWTxGnNdmPz/JS4GdvHhw+Kl0cC2OQmvOKLDTSV423hj4WjaUBDqfdeAIZVMq0vLg==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
+      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-16.4.0.tgz",
-      "integrity": "sha512-tVzMUV7vVy3H6M5kCgDxnL8EXRvDic0+GUb6fmzdsemU/HkA+zlKDbvKs9bfI79hX3EWeptFN2GOXnrGB84MbQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
+      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.4.0.tgz",
-      "integrity": "sha512-h0QVBtyzs0/ICLIDBDB1DFzmdvyCHfJB/AFxaonFJ7f6PIrUEFz/HjxvX8jMhcCllRxUrslWqF6DC9Gs76isVw==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
+      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@lerna/legacy-package-management": "^8.2.4",
-    "@lvce-editor/eslint-config": "^16.4.0",
+    "@lvce-editor/eslint-config": "^17.0.3",
     "eslint": "^10.7.0",
     "lerna": "^8.2.4",
     "prettier": "^3.8.4",

--- a/packages/completion-worker/src/parts/GetCompletionDetailVirtualDom/GetCompletionDetailVirtualDom.ts
+++ b/packages/completion-worker/src/parts/GetCompletionDetailVirtualDom/GetCompletionDetailVirtualDom.ts
@@ -5,6 +5,20 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 
+const completionDetailContentNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.CompletionDetailContent,
+  type: VirtualDomElements.Div,
+}
+
+const completionDetailCloseButtonNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.CompletionDetailCloseButton,
+  onClick: DomEventListenerFunctions.HandleClose,
+  role: AriaRoles.Button,
+  type: VirtualDomElements.Div,
+}
+
 export const getCompletionDetailVirtualDom = (content: string): readonly VirtualDomNode[] => {
   const dom: readonly VirtualDomNode[] = [
     {
@@ -12,19 +26,9 @@ export const getCompletionDetailVirtualDom = (content: string): readonly Virtual
       className: MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames.EditorCompletionDetails),
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 1,
-      className: ClassNames.CompletionDetailContent,
-      type: VirtualDomElements.Div,
-    },
+    completionDetailContentNode,
     text(content),
-    {
-      childCount: 1,
-      className: ClassNames.CompletionDetailCloseButton,
-      onClick: DomEventListenerFunctions.HandleClose,
-      role: AriaRoles.Button,
-      type: VirtualDomElements.Div,
-    },
+    completionDetailCloseButtonNode,
     {
       childCount: 0,
       className: MergeClassNames.mergeClassNames(ClassNames.MaskIcon, ClassNames.IconClose),

--- a/packages/completion-worker/test/ExtensionManagementCompletion.test.ts
+++ b/packages/completion-worker/test/ExtensionManagementCompletion.test.ts
@@ -115,7 +115,9 @@ test('executeResolveCompletionItem returns resolved completion item', async () =
     ['Editor.getLines2', 1],
     ['Editor.getUri', 1],
   ])
-  expect(mockExtensionManagementRpc.invocations).toEqual([['Extensions.executeResolveCompletionItemProvider', textDocument, 10, 'test', completionItem]])
+  expect(mockExtensionManagementRpc.invocations).toEqual([
+    ['Extensions.executeResolveCompletionItemProvider', textDocument, 10, 'test', completionItem],
+  ])
   expect(mockExtensionHostRpc.invocations).toEqual([])
 })
 
@@ -143,6 +145,8 @@ test('executeResolveCompletionItem returns undefined when no provider found', as
     ['Editor.getLines2', 1],
     ['Editor.getUri', 1],
   ])
-  expect(mockExtensionManagementRpc.invocations).toEqual([['Extensions.executeResolveCompletionItemProvider', textDocument, 10, 'test', completionItem]])
+  expect(mockExtensionManagementRpc.invocations).toEqual([
+    ['Extensions.executeResolveCompletionItemProvider', textDocument, 10, 'test', completionItem],
+  ])
   expect(mockExtensionHostRpc.invocations).toEqual([])
 })


### PR DESCRIPTION
Update ESLint and the shared config to the latest release, hoist the two static completion-detail nodes, and apply the existing test formatting cleanup surfaced by validation.