### PR TITLE
fix: serialize package bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "node packages/build/src/dev.js",
     "e2e": "cd packages/e2e && npm run e2e:headless",
     "format": "prettier --write .",
-    "postinstall": "lerna bootstrap --ci",
+    "postinstall": "lerna bootstrap --ci --concurrency 1",
     "lint": "eslint .",
     "measure": "cd packages/memory && npm run measure",
     "test": "lerna run test",


### PR DESCRIPTION
Serialize Lerna package installs to prevent the nested npm process from crashing on Windows during CI bootstrap.